### PR TITLE
added .htaccess to redirect routes through index.php

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,6 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ index.php [L]
+</IfModule>


### PR DESCRIPTION
asides '/', no every other route returns 404 except the site is served using 'php server'. this means all other routes won't work when using 'virtual host'. fixed this by adding a '.htaccess' file in the public/ directory to redirect routes through index.php so routes (except '/') don't return 404.